### PR TITLE
Update Script_3_StationaryPoints.py - jobid instead of part of string

### DIFF
--- a/Script_3_StationaryPoints.py
+++ b/Script_3_StationaryPoints.py
@@ -268,11 +268,20 @@ import subprocess
 
 inp_file_job_ids = []
 
+def jobid(filename):
+    match = re.findall(r"(\d+)", filename) #Finds all sequences of numbers
+    if match:
+        for group in match:
+            if len(group)==4: #if sequence of numbers is 4 units long then return that as the jobid; unlikely that in name a sequence of 4 numbers would be added
+                numbers=group
+    return numbers
+
 def launcherstatp(logfilelist):
     for i, logfile1 in enumerate(logfilelist):
-        number = logfile1[17:21]
+        number1 = jobid(logfile1)
         for j, logfile2 in enumerate(logfilelist):
-            if number in logfile2 and logfile1 != logfile2 and j > i:
+	    number2 = jobid(logfile2)
+            if number1==number2  and logfile1 != logfile2 and j > i:
                 geometry1 = geometryextractor(logfile1)
                 updated_geometry1 = geometryconverter(geometry1)
                 distance1_CC1 = distance(updated_geometry1, CC1)


### PR DESCRIPTION
In the previous code, the number of the job was retrieved by taking the respective part of the string that corresponded to the jobid. The problem is of course that if the position changes, that the jobid is not recognized anymore and IRCs start to be crossed with one another leading to both reagent and product for the same IRC part being calculated or the code crashing as the inputfile already existed. To solve it I made a function that finds the jobid and then implemented it into the function. We might have been just lucky until now and had the right positioning of job.

Criteria for it to work: no other 4-number sequence which seems pretty unlikely.